### PR TITLE
[Docs] Add OR3 Cloud plugin access gating plan

### DIFF
--- a/planning/or3-cloud-plugin-access-gating/design.md
+++ b/planning/or3-cloud-plugin-access-gating/design.md
@@ -1,0 +1,186 @@
+---
+artifact_id: 57f4502a-b04d-4563-b6d4-987341f7e04a
+title: Design - OR3 Cloud plugin access gating
+status: draft
+owner: platform
+date: 2026-02-19
+---
+
+# Overview
+
+This design introduces a unified plugin access-gating layer for OR3 Cloud. It adds declarative policy primitives that can be defined in plugin code and overridden by admins per workspace.
+
+The design is intentionally provider-agnostic and aligned with OR3 constraints:
+- canonical workspace/user data stays in the selected `AuthWorkspaceStore`,
+- SSR endpoint authorization remains enforced through `can()`,
+- extension points (hooks/registries/composables) are preferred over hard-coded logic,
+- static builds must remain functional and avoid server-only imports.
+
+# Current-state findings (gap summary)
+
+1. Plugin manifests currently expose general `capabilities` metadata but no built-in auth/entitlement gating contract.
+2. Admin plugin controls currently support workspace-level enable/disable and free-form settings storage, but no first-class gate schema.
+3. UI registries expose ad-hoc visibility callbacks, so plugin authors can custom-gate in code, but there is no shared policy evaluator, no consistent deny reasons, and no central admin override model.
+
+# Architecture
+
+```mermaid
+flowchart LR
+    A[Plugin registration\n(code defaults)] --> B[Gate Policy Resolver]
+    C[Admin plugin settings\nworkspace overrides] --> B
+    D[Session Context\nauth/workspace/role] --> B
+    E[Entitlement Resolver\n(provider-agnostic)] --> B
+
+    B --> F[Client composables\nvisibility/disabled state]
+    B --> G[Server guards\nrequireCan + policy check]
+
+    G --> H[SSR API response\nallow/deny + reason code]
+```
+
+## Core components
+
+1. **PluginGatePolicy schema (shared)**
+   - Defines typed policy fields (`authRequired`, `requiredEntitlements`, `requiredWorkspaceRoles`, `mode`).
+   - Lives in shared code so client and server can evaluate the same structure.
+
+2. **Gate Policy Resolver (shared/composable + server helper)**
+   - Merges code defaults with admin overrides using deterministic precedence:
+     1) secure system defaults,
+     2) plugin-declared defaults,
+     3) workspace admin overrides.
+   - Produces normalized effective policy and validation errors.
+
+3. **Entitlement Resolver registry (server-first, client-safe snapshot)**
+   - New provider extension point:
+     - server resolver computes user entitlements for workspace (`free`, `paid`, `enterprise`, feature flags).
+     - optional client snapshot endpoint for non-sensitive UI gating hints.
+   - Default resolver returns empty entitlements (maintains backward compatibility).
+
+4. **Plugin Gate Evaluator**
+   - Pure function evaluating `(policy, session, entitlements, pluginEnabled)`.
+   - Returns structured decision:
+     - `allowed: boolean`
+     - `reasons: PluginGateDenyReason[]`
+     - `effectivePolicy`
+
+5. **Admin API + UI integration**
+   - Extend admin workspace plugin settings contract with validated `access` block.
+   - Add admin dashboard editor controls for common gate patterns:
+     - auth required toggle,
+     - minimum tier selector,
+     - role requirement multi-select.
+
+6. **Server action guard integration**
+   - For SSR routes owned by plugin features, evaluate plugin policy before business logic.
+   - Final authz remains `can()` for resource operations; plugin gate acts as precondition layer.
+
+# Data contracts
+
+## Shared policy types (TypeScript sketch)
+
+```ts
+export type EntitlementId = string;
+export type WorkspaceRole = 'owner' | 'editor' | 'viewer';
+
+export interface PluginGatePolicy {
+  authRequired?: boolean;
+  requiredEntitlements?: EntitlementId[];
+  requiredWorkspaceRoles?: WorkspaceRole[];
+  mode?: 'all' | 'any';
+}
+
+export type PluginGateDenyReason =
+  | 'plugin-disabled'
+  | 'unauthenticated'
+  | 'missing-entitlement'
+  | 'insufficient-role'
+  | 'invalid-policy';
+
+export interface PluginGateDecision {
+  allowed: boolean;
+  reasons: PluginGateDenyReason[];
+  effectivePolicy: Required<PluginGatePolicy>;
+}
+```
+
+## Workspace settings shape (additive)
+
+Stored under existing plugin settings namespace, per plugin:
+
+```json
+{
+  "access": {
+    "authRequired": true,
+    "requiredEntitlements": ["paid"],
+    "requiredWorkspaceRoles": ["owner", "editor"],
+    "mode": "all"
+  }
+}
+```
+
+Notes:
+- additive under existing `plugins.settings.{pluginId}`;
+- unknown keys remain preserved by existing settings store behavior;
+- policy block validated by Zod before persistence.
+
+# Integration points
+
+## Client surfaces
+
+- `useDashboardPlugins` / dashboard page resolution:
+  - filter or disable entries based on gate decision.
+- sidebar registries (`useSidebarSections`, `useSidebarPages`, header/composer actions):
+  - apply shared evaluator output for consistent visibility behavior.
+- message action registry:
+  - optional guard wrapper so gated actions do not render or execute.
+
+## Server surfaces
+
+- New helper in server plugin infra:
+  - `requirePluginAccess(event, { pluginId, action })`.
+- helper pipeline:
+  1) resolve session,
+  2) resolve workspace plugin enabled state,
+  3) load plugin settings policy,
+  4) resolve entitlements,
+  5) evaluate policy,
+  6) enforce denial before action,
+  7) continue to `requireCan()` for resource authorization.
+
+# Error handling
+
+- Invalid admin policy payload → `400 Invalid request` with field-level issues (safe details).
+- Gate denial on SSR action → `403 Forbidden` with reason code.
+- Missing entitlement resolver/provider outage:
+  - fail closed for policies that require entitlements,
+  - emit server log warning with workspace/plugin context.
+- Static build / SSR auth disabled:
+  - evaluator treats session as unauthenticated unless explicit local-safe override is configured.
+
+# Security and performance considerations
+
+- Security:
+  - never rely on client-only visibility checks; server enforcement required for protected actions.
+  - `can()` remains sole resource authorization gate.
+- Performance:
+  - memoize effective policy per `(workspaceId, pluginId, policyVersion)` in request-local cache.
+  - batch entitlement resolution per request to avoid repeated provider calls.
+
+# Testing strategy
+
+1. **Unit**
+   - policy schema normalization and merge precedence.
+   - evaluator matrix (`authRequired`, tier, role, mode any/all).
+   - deterministic deny reason ordering.
+
+2. **Integration**
+   - admin API save/load for `access` block.
+   - plugin enable + access policy interactions.
+   - client composables consume effective decision and hide/disable correctly.
+
+3. **SSR/API integration**
+   - protected route with plugin gate denies unauthenticated and non-paid users.
+   - authorized paid user passes plugin gate, then `can()` governs resource-level authorization.
+
+4. **E2E (follow-up)**
+   - workspace admin sets policy in dashboard; another user sees feature availability update after session refresh.

--- a/planning/or3-cloud-plugin-access-gating/requirements.md
+++ b/planning/or3-cloud-plugin-access-gating/requirements.md
@@ -1,0 +1,92 @@
+---
+artifact_id: b7c4f95e-8ff2-4fcb-a7ab-bdd91b4bbf54
+title: Requirements - OR3 Cloud plugin access gating
+status: draft
+owner: platform
+date: 2026-02-19
+---
+
+# Overview
+
+OR3 currently supports plugin installation, workspace enable/disable, and arbitrary plugin settings, but does not provide a built-in, declarative policy model for feature gating based on authentication and entitlements (for example, "auth required" or "paid tier required").
+
+This plan defines requirements for a provider-agnostic plugin access-gating system that:
+- allows plugin authors to declare gate intent in code,
+- allows admins to configure gate policies from the admin dashboard,
+- evaluates gates consistently in client and server paths,
+- preserves local-first behavior while enforcing authoritative SSR checks for protected operations.
+
+# Requirements
+
+## 1. Add declarative gate policies for plugins
+
+**User Story 1.1**
+As a plugin author, I want to declare access requirements for plugin features, so that visibility and execution rules are defined in one predictable policy surface.
+
+**Acceptance Criteria**
+- WHEN a plugin is registered THEN it SHALL be able to declare gate metadata (e.g., `authRequired`, `requiredEntitlements`, `requiredRoles`) using a typed contract.
+- IF a plugin provides no gate metadata THEN the system SHALL default to current behavior (no additional gating beyond existing enable/disable).
+- The gate contract SHALL be provider-agnostic and SHALL not embed Clerk/Convex-specific assumptions.
+
+## 2. Support admin-managed gate configuration per workspace
+
+**User Story 2.1**
+As a workspace owner/admin, I want to configure plugin gate rules from the admin dashboard, so that access can be adjusted without redeploying plugin code.
+
+**Acceptance Criteria**
+- WHEN an admin updates gate settings for a plugin THEN settings SHALL be persisted in the existing workspace plugin settings store.
+- Gate config SHALL support at minimum:
+  - authenticated-only access,
+  - entitlement/tier requirements (e.g., `paid`),
+  - optional role constraints (e.g., `owner`, `editor`).
+- IF invalid gate config is submitted THEN the API SHALL return 400 and SHALL NOT persist partial updates.
+
+## 3. Enforce gate decisions consistently across UI and protected actions
+
+**User Story 3.1**
+As an end user, I want gated features to be hidden/disabled consistently and denied server-side when required, so behavior is predictable and secure.
+
+**Acceptance Criteria**
+- WHEN a feature is gated off THEN plugin entry points (dashboard tiles/pages, sidebar actions/pages, message actions) SHALL not be presented as active affordances.
+- WHEN a gated action is attempted via SSR endpoint THEN authorization SHALL be enforced server-side using `can()` as the final decision gate.
+- IF client and server disagree due to stale cache/session THEN server denial SHALL be authoritative and a clear UX message SHALL be shown.
+
+## 4. Preserve extension model and static-build guarantees
+
+**User Story 4.1**
+As a platform maintainer, I want gating to integrate with existing hooks/registries/composables, so the architecture stays extensible and static builds remain safe.
+
+**Acceptance Criteria**
+- Gate evaluation SHALL be exposed through extension points (hook/composable), not hard-coded singleton checks.
+- SSR-only auth/entitlement resolvers SHALL remain in server code paths and SHALL not be imported into static-only bundles.
+- IF SSR auth is disabled THEN entitlement-dependent gates SHALL degrade to a deterministic local-safe mode (e.g., deny protected features or treat as unauthenticated per policy).
+
+## 5. Provide observability and operability
+
+**User Story 5.1**
+As an operator, I want visibility into why a plugin gate denied access, so I can debug policy issues quickly.
+
+**Acceptance Criteria**
+- Gate decisions SHALL include structured denial reasons (`unauthenticated`, `missing-entitlement`, `insufficient-role`, `plugin-disabled`, etc.).
+- Admin/API responses for policy testing endpoints SHALL include machine-readable reason codes.
+- Security-sensitive details SHALL not leak to unauthorized users.
+
+## 6. Backward compatibility and migration
+
+**User Story 6.1**
+As an existing OR3 deployment owner, I want plugin behavior to continue working until policies are explicitly configured, so upgrades are non-breaking.
+
+**Acceptance Criteria**
+- Existing plugins without gate metadata SHALL remain functional under current enable/disable semantics.
+- Existing `plugins.settings.*` data SHALL remain valid and readable.
+- Migration SHALL be additive and SHALL NOT require reinstalling plugins.
+
+## 7. Testing coverage
+
+**User Story 7.1**
+As a maintainer, I want strong automated coverage for gate logic and policy enforcement, so regressions are caught early.
+
+**Acceptance Criteria**
+- Unit tests SHALL cover gate policy normalization, merge precedence (code defaults + admin overrides), and denial reasons.
+- Integration tests SHALL cover admin gate config save/load and UI-consumable policy responses.
+- SSR integration tests SHALL verify protected routes deny unauthorized/under-entitled users using `can()`.

--- a/planning/or3-cloud-plugin-access-gating/tasks.md
+++ b/planning/or3-cloud-plugin-access-gating/tasks.md
@@ -1,0 +1,83 @@
+---
+artifact_id: 5a0f4ca4-43ef-4835-a8d4-2c7347d9cd4f
+title: Tasks - OR3 Cloud plugin access gating
+status: draft
+owner: platform
+date: 2026-02-19
+---
+
+# 1. Define shared gate policy model
+
+- [ ] Add shared TypeScript + Zod schema for plugin access policy and denial reasons. Requirements: 1.1, 5.1
+- [ ] Add shared evaluator utility returning structured decisions. Requirements: 3.1, 5.1
+- [ ] Add merge utility for code defaults + admin overrides with deterministic precedence. Requirements: 1.1, 2.1, 6.1
+
+## Tests
+- [ ] Add evaluator matrix unit tests (auth/tier/role/mode combinations). Requirements: 7.1
+- [ ] Add invalid policy normalization tests and reason-code assertions. Requirements: 5.1, 7.1
+
+# 2. Extend plugin registration contracts
+
+- [ ] Add optional `access` policy field to plugin registration/manifest-facing types. Requirements: 1.1, 6.1
+- [ ] Keep default behavior unchanged when `access` is missing. Requirements: 1.1, 6.1
+- [ ] Document plugin-author examples for common policies (`authRequired`, `paid`). Requirements: 1.1
+
+## Tests
+- [ ] Add backward-compat tests showing legacy plugins register and function unchanged. Requirements: 6.1, 7.1
+
+# 3. Add admin policy persistence and validation
+
+- [ ] Extend admin plugin settings endpoints to validate/persist `settings.access` policy block. Requirements: 2.1
+- [ ] Return normalized effective policy in read APIs (or add dedicated policy endpoint). Requirements: 2.1, 5.1
+- [ ] Preserve unknown plugin settings fields while updating `access`. Requirements: 6.1
+
+## Tests
+- [ ] Add API tests for valid `access` writes and reads. Requirements: 2.1, 7.1
+- [ ] Add API tests for invalid `access` payload rejection (400). Requirements: 2.1, 7.1
+
+# 4. Introduce entitlement resolver extension point
+
+- [ ] Add server registry interface for entitlement resolution (`resolveEntitlements(session, workspace)`). Requirements: 1.1, 4.1
+- [ ] Provide default no-entitlement implementation for compatibility. Requirements: 6.1
+- [ ] Add provider integration guidance for mapping billing tiers to entitlement IDs. Requirements: 2.1
+
+## Tests
+- [ ] Add unit tests for default resolver behavior and registry replacement. Requirements: 4.1, 7.1
+
+# 5. Apply gating to UI registries/composables
+
+- [ ] Integrate gate evaluator into dashboard plugin visibility/disabled states. Requirements: 3.1
+- [ ] Integrate gating into sidebar pages/actions and message actions via shared guard helper. Requirements: 3.1, 4.1
+- [ ] Ensure deny reasons can be surfaced in optional UX messaging (non-sensitive). Requirements: 5.1
+
+## Tests
+- [ ] Add composable tests for hidden vs disabled outcomes by policy decision. Requirements: 3.1, 7.1
+
+# 6. Add server-side enforcement helper
+
+- [ ] Implement `requirePluginAccess` helper for SSR endpoints with plugin ID context. Requirements: 3.1, 4.1
+- [ ] Ensure helper composes with `requireCan()` (plugin gate first, resource auth second). Requirements: 3.1
+- [ ] Apply helper to at least one representative plugin-owned SSR route as reference implementation. Requirements: 3.1, 4.1
+
+## Tests
+- [ ] Add route tests for unauthenticated deny, missing entitlement deny, allowed paid-user path. Requirements: 3.1, 7.1
+
+# 7. Admin dashboard UX for policy editing
+
+- [ ] Add policy controls on `admin/plugins` page (auth toggle, tier selector, role selector). Requirements: 2.1
+- [ ] Load/save controls through existing workspace plugin settings APIs. Requirements: 2.1, 6.1
+- [ ] Add guardrails/help text explaining server-side enforcement and policy precedence. Requirements: 5.1
+
+## Tests
+- [ ] Add component tests for policy form serialization/deserialization. Requirements: 2.1, 7.1
+
+# 8. Documentation and rollout
+
+- [ ] Update plugin docs with new access policy contract and examples. Requirements: 1.1, 6.1
+- [ ] Update cloud docs with entitlement resolver extension pattern. Requirements: 4.1
+- [ ] Add migration notes (non-breaking default behavior). Requirements: 6.1
+
+# 9. Validation
+
+- [ ] Run `bun run test` for affected suites. Requirements: 7.1
+- [ ] Run `bun run lint` and fix only introduced issues. Requirements: 7.1


### PR DESCRIPTION
### Motivation
- Provide a first-class, provider-agnostic way to gate plugin features by auth and entitlements (e.g., require authenticated users or a paid tier) so UI affordances and SSR routes behave consistently and securely.
- Allow workspace admins to configure gate policies at install-time or from the admin dashboard without changing plugin code, while preserving local-first/static-build guarantees and server-side enforcement with `can()`.

### Description
- Added a planning bundle at `planning/or3-cloud-plugin-access-gating/` containing `requirements.md`, `design.md`, and `tasks.md` that define user stories, a provider-agnostic design (shared `PluginGatePolicy`, policy resolver, entitlement resolver extension point, `requirePluginAccess` helper), and an implementation checklist mapped to tests and rollout steps.
- The `requirements.md` specifies acceptance criteria for plugin-declared defaults, admin-managed workspace overrides, consistent client+server enforcement, observability (deny reasons), and backward-compatibility guarantees.
- The `design.md` describes architecture, shared type sketches (`PluginGatePolicy`, `PluginGateDecision`), integration points for client registries and SSR endpoints, error handling, and testing strategy; the `tasks.md` enumerates concrete implementation tasks and test coverage to be added.

### Testing
- No automated tests were run for this PR because it only adds planning/documentation files; implementation tasks include unit, integration and SSR test plans to be added in follow-up changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967b1098d08327b9b219f143712856)